### PR TITLE
Only $apply callbacks if not already in digest cycle

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -8,12 +8,19 @@
 
 angular.module('btford.socket-io', []).
   factory('socket', function ($rootScope) {
+    var safeApply = function(scope, fn) {
+      if (scope.$$phase) {
+        fn();
+      } else {
+        scope.$apply(fn);
+      }
+    };
     var socket = io.connect();
     return {
       on: function (eventName, callback) {
-        socket.on(eventName, function () {  
+        socket.on(eventName, function () {
           var args = arguments;
-          $rootScope.$apply(function () {
+          safeApply($rootScope, function () {
             callback.apply(socket, args);
           });
         });
@@ -21,7 +28,7 @@ angular.module('btford.socket-io', []).
       emit: function (eventName, data, callback) {
         socket.emit(eventName, data, function () {
           var args = arguments;
-          $rootScope.$apply(function () {
+          safeApply($rootScope, function () {
             if (callback) {
               callback.apply(socket, args);
             }


### PR DESCRIPTION
With Socket.IO, it's possible that an event can chain into other events, thus firing multiple callbacks. In this case, the service will call `$rootScope.$apply` even though we're already inside the scope lifecycle.

This patch introduces a check on `$rootScope.$$phase` to decide whether or not to execute the callback via `$apply`. The code is based on a StackOverflow question I answered regarding this issue: http://stackoverflow.com/questions/14700865
