### PR TITLE
emit fix/support for multiple arguments

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -34,7 +34,7 @@ angular.module('btford.socket-io', []).
         on: addListener,
         addListener: addListener,
 
-        emit: function (eventName, data, callback) {
+        emit: function () {
           var lastIndex = arguments.length - 1;
 
           if ('function' == typeof arguments[lastIndex]) {


### PR DESCRIPTION
_socket.emit_ in socket.io supports multiple arguments like this including a callback:

```
socket.emit('some event', 'a', 'b', 'c', my_callback)
```

_emit_ doesn't work if you do something like this:

```
socket.emit('join', channel_name, nickname)
```

because _emit_ thinks nickname is _callback_.
