### PR TITLE
Added reconnect() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ angular.module('myMod', ['btford.socket-io']).
   });
 ```
 
+### `socket.reconnect`
+Reconnect client to the server.
+
 ### `socketProvider.prefix`
 
 This method changes the prefix for forwarded events.

--- a/socket.js
+++ b/socket.js
@@ -35,6 +35,10 @@ angular.module('btford.socket-io', []).
         on: addListener,
         addListener: addListener,
 
+        reconnect: function() {
+          socket.socket.reconnect();
+        },
+
         emit: function (eventName, data, callback) {
           if (callback) {
             socket.emit(eventName, data, asyncAngularify(callback));


### PR DESCRIPTION
This method is useful when the client needs to be reconnected to the server.

Example : I have an app with Socket.io + Express for an API. The user must login before he can use the socket.
So when the Angular App start, the server refuses the handshake if the user is not logged in. Once logged in, I must restart the connection from the client to let the user use the socket.
