### PR TITLE
Fix $scope.on to $scope.$on in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ run(function (socket) {
 // in one of your controllers
 angular.module('myApp.MyCtrl', []).
   controller('MyCtrl', function ($scope) {
-    $scope.on('socket:error', function (ev, data) {
+    $scope.$on('socket:error', function (ev, data) {
 
     });
   });


### PR DESCRIPTION
This PR fixes a small error in the README: `$scope.on` should be `$scope.$on`. It threw me when trying out angular-socket-io until I spotted it. Without the additional `$`, I was getting an error:

```
TypeError: Object #<Scope> has no method 'on'
```
