### PR TITLE
Expose socket.socket

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -38,6 +38,7 @@ angular.module('btford.socket-io', []).
         var wrappedSocket = {
           on: addListener,
           addListener: addListener,
+          socket: socket.socket,
 
           emit: function (eventName, data, callback) {
             return socket.emit(eventName, data, asyncAngularify(socket, callback));


### PR DESCRIPTION
Sometimes you need to access the unwrapped `socket.socket` for things like `socket.socket.connected` or `socket.socket.reconnect()`. Instead of wrapping those socket-functions i would prefer exposing the socket-object.

This is also related to #22 (reconnect)

What do you think? 
