### PR TITLE
Added support for multiple data argments with emit

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -40,7 +40,12 @@ angular.module('btford.socket-io', []).
           addListener: addListener,
 
           emit: function (eventName, data, callback) {
-            return socket.emit(eventName, data, asyncAngularify(socket, callback));
+            var args = arguments;
+            var callback = args[args.length - 1];
+            if(typeof callback == 'function') {
+              callback = asyncAngularify(socket, callback);
+            }
+            return socket.emit.apply(socket, args); 
           },
 
           removeListener: function () {


### PR DESCRIPTION
Allows users to send multiple arguments through `socket.emit`. Angularify's if and **only** if the last argument present is a function, then uses that as the callback.
