### PR TITLE
Fix minify problem

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -15,7 +15,7 @@ angular.module('btford.socket-io', []).
       ioSocket;
 
     // expose to provider
-    this.$get = function ($rootScope, $timeout) {
+    this.$get = ["$rootScope", "$timeout", function ($rootScope, $timeout) {
 
       var asyncAngularify = function (socket, callback) {
         return callback ? function () {
@@ -81,5 +81,5 @@ angular.module('btford.socket-io', []).
 
         return wrappedSocket;
       };
-    };
+    }];
   });


### PR DESCRIPTION
Implicit inject dependencies on this function to avoid error after minifying. I know that I could use your socket.min.js separately but I have a build task that minifies 3rd-party libraries in which there is socket.js. Moreover, I think that would not be risky to inject dependencies implicitly.
