### PR TITLE
chore: move karma-coverage devDependency to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "gulp-ngmin": "~0.1.2",
     "karma": "~0.10.2",
     "karma-jasmine": "~0.1.3",
-    "karma-firefox-launcher": "~0.1.0"
-  },
-  "dependencies": {
+    "karma-firefox-launcher": "~0.1.0",
     "karma-coverage": "~0.1.4"
   }
 }


### PR DESCRIPTION
When using npm installing angular-socket-io for use with Browserify, it downloads karma-coverage as a dependency.  This amends that.
