### PR TITLE
fix it so all socket.io args are passed to scope on socket.forward

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -81,8 +81,9 @@ angular.module('btford.socket-io', []).
             }
             events.forEach(function (eventName) {
               var prefixedEvent = prefix + eventName;
-              var forwardBroadcast = asyncAngularify(socket, function (data) {
-                scope.$broadcast(prefixedEvent, data);
+              var forwardBroadcast = asyncAngularify(socket, function () {
+                Array.prototype.unshift.call(arguments, prefixedEvent);
+                scope.$broadcast.apply(scope, arguments);
               });
               scope.$on('$destroy', function () {
                 socket.removeListener(eventName, forwardBroadcast);


### PR DESCRIPTION
Right now, you are truncating args passed from the socket through to the scope.  

For example, if the server side does this:

``` javascript
socket.emit('event:name', { first: 'first arg'}, { second: 'second arg' });
```

On the client, socket.io receives both, but you are truncating it, so you end up with this:

``` javascript
.controller('FooCtrl', function (mysocket, $scope) {
  // mysocket is the factory wrapper
  mysocket.forward('event:name', $scope);
  $scope.$on('socket:event:name', function () {
    console.log('arguments: ', arguments); 
  });
});
```

Will print the first arg as the event object, second arg would be `{ first: 'first arg' }` and there will be no more args.

This PR fixes that.
