### PR TITLE
Accepting an empty prefix for events if given

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -29,7 +29,7 @@ angular.module('btford.socket-io', []).
       return function socketFactory (options) {
         options = options || {};
         var socket = options.ioSocket || io.connect();
-        var prefix = options.prefix || defaultPrefix;
+        var prefix = options.prefix === undefined ? defaultPrefix : options.prefix ;
         var defaultScope = options.scope || $rootScope;
 
         var addListener = function (eventName, callback) {

--- a/socket.spec.js
+++ b/socket.spec.js
@@ -212,6 +212,22 @@ describe('socketFactory', function () {
       expect(spy).toHaveBeenCalled();
     }));
 
+    it('should use an empty prefix if specified', inject(function (socketFactory) {
+      var socket = socketFactory({
+        ioSocket: mockIoSocket,
+        scope: scope,
+        prefix: ''
+      });
+
+      socket.forward('event');
+
+      scope.$on('event', spy);
+      mockIoSocket.emit('event');
+      $timeout.flush();
+
+      expect(spy).toHaveBeenCalled();
+    }));
+
     it('should forward to the specified scope when one is provided', function () {
       var child = scope.$new();
       spyOn(child, '$broadcast');


### PR DESCRIPTION
Please accept the following pull request to optionally allow the removal of event name prefixes.  Although prefixing is probably the correct choice for complex problem domains, for simple use cases where it is desired the event be directly passed requires an adapter between the prefix and actual event.
