### PR TITLE
Missing "repository" field added in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "scripts": {
     "test": "./node_modules/.bin/karma start --browsers Firefox --single-run"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/btford/angular-socket-io.git"
+  },
   "author": "Brian Ford",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This fixes a warning when using NPM:

```
npm WARN package.json angular-socket-io@0.7.0 No repository field.
```
