### PR TITLE
Remove unused parameters from emit, fixes issue 112

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -45,7 +45,7 @@ angular.module('btford.socket-io', []).
           addListener: addListener,
           once: addOnceListener,
 
-          emit: function (eventName, data, callback) {
+          emit: function () {
             var lastIndex = arguments.length - 1;
             var callback = arguments[lastIndex];
             if(typeof callback == 'function') {


### PR DESCRIPTION
Causing issues with IE9. Parameters are unused anyway.

See: https://github.com/btford/angular-socket-io/issues/112

Other options are to rename either the function parameter `callback` or the internal parameter `callback`