### PR TITLE
Remove unnecessary "var" from emit()

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -47,7 +47,7 @@ angular.module('btford.socket-io', []).
 
           emit: function (eventName, data, callback) {
             var lastIndex = arguments.length - 1;
-            var callback = arguments[lastIndex];
+            callback = arguments[lastIndex];
             if(typeof callback == 'function') {
               callback = asyncAngularify(socket, callback);
               arguments[lastIndex] = callback;


### PR DESCRIPTION
We already have **callback** as parameter. Therefore the variable is defined locally. No need to redefine it inside the function with an explicit **var**.
