### PR TITLE
Copied license statement over from package.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 BTFORD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "angular-socket-io",
   "version": "0.7.0",
   "main": "socket.js",
+  "license": "MIT", 
   "dependencies": {
     "angular": "^1.2.6"
   },

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-socket-io",
   "version": "0.7.0",
   "main": "socket.js",
-  "license": "MIT", 
+  "license": ["MIT"], 
   "dependencies": {
     "angular": "^1.2.6"
   },

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-socket-io",
   "version": "0.7.0",
   "main": "socket.js",
-  "license": ["MIT"], 
+  "license": "MIT", 
   "dependencies": {
     "angular": "^1.2.6"
   },


### PR DESCRIPTION
This is to support deployment to webjars.org so that people can pull the dependency to JVM based applications such as SpringBoot